### PR TITLE
ts target changed to es5 to conform with fp-ts

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "es5",
         "noImplicitAny": true,
         "strict": true,
         "noImplicitReturns": true,


### PR DESCRIPTION
This allows the usage of `decode-ts` everywhere `fp-ts` can be used.

Currently I experience errors on older platforms like Android 4.4 which does not support the `const` keyword.