### PR TITLE
Upgrade fp-ts, io-ts and io-ts-reporters

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "target"
   ],
   "dependencies": {
-    "fp-ts": "^1.0.1",
-    "io-ts": "^1.0.2",
-    "io-ts-reporters": "^0.0.21",
+    "fp-ts": "^2.3.1",
+    "io-ts": "^2.0.2",
+    "io-ts-reporters": "^1.0.0",
     "unionize": "^1.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,7 +78,6 @@ concat-map@0.0.1:
 diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
-  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -88,9 +87,9 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-fp-ts@^1.0.0, fp-ts@^1.0.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-1.7.1.tgz#b1ff2a39f345a7aa31bb53f26edab1ac3fc70b75"
+fp-ts@^2.0.2, fp-ts@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.3.1.tgz#8068bfcca118227932941101e062134d7ecd9119"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -128,18 +127,16 @@ inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-io-ts-reporters@^0.0.21:
-  version "0.0.21"
-  resolved "https://registry.yarnpkg.com/io-ts-reporters/-/io-ts-reporters-0.0.21.tgz#b0be3eec37a3d7da77aeafa257c68bd2afbbc4af"
+io-ts-reporters@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/io-ts-reporters/-/io-ts-reporters-1.0.0.tgz#c5901d49d454956698bbca48b328698f8ca1c9c7"
   dependencies:
-    fp-ts "^1.0.1"
-    io-ts "^1.0.2"
+    fp-ts "^2.0.2"
+    io-ts "^2.0.0"
 
-io-ts@^1.0.2:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-1.3.0.tgz#72a5e7dbbb650b9c26030bac0c22d9b18c321f54"
-  dependencies:
-    fp-ts "^1.0.0"
+io-ts@^2.0.0, io-ts@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.0.3.tgz#1921e82a9f77d8a3ed191b4b82b33ac74c09b4bb"
 
 js-tokens@^3.0.0:
   version "3.0.2"
@@ -224,7 +221,6 @@ tsutils@^2.12.1:
 typescript@^3.7.4:
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
-  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 unionize@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Thanks for those simple but effective time-saver functions. They are very useful.
We've upgraded the dependencies for fp-ts & io-ts to latest 2.x to prevent dependency conflicts:
* `fp-ts` from 1.0.1 to 2.3.1
* `io-ts` from 1.0.2 to 2.0.2
* `io-ts-reporters` from 0.0.21 to 1.0.0

Can those changes be merged like this? Or should older 2.x versions be used?