### PR TITLE
Upgrade typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "tslint": "^5.8.0",
     "tslint-language-service": "0.9.6",
-    "typescript": "^2.7.2"
+    "typescript": "^3.7.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,9 +220,10 @@ tsutils@^2.12.1:
   dependencies:
     tslib "^1.7.1"
 
-typescript@^2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
+typescript@^3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 unionize@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Upgrading typescript from v2.x to v3.x. 
Required for #6, but still compiles the current master branch without any errors.